### PR TITLE
Add target API methods

### DIFF
--- a/buddy/client.go
+++ b/buddy/client.go
@@ -62,6 +62,7 @@ type Client struct {
 	IntegrationService   *IntegrationService
 	PipelineService      *PipelineService
 	EnvironmentService   *EnvironmentService
+	TargetService        *TargetService
 	TokenService         *TokenService
 	SourceService        *SourceService
 }
@@ -223,6 +224,7 @@ func NewClientWithTimeout(token string, baseUrl string, insecure bool, timeout t
 	c.VariableService = &VariableService{client: c}
 	c.IntegrationService = &IntegrationService{client: c}
 	c.PipelineService = &PipelineService{client: c}
+	c.TargetService = &TargetService{client: c}
 	c.SourceService = &SourceService{client: c}
 	c.SsoService = &SsoService{client: c}
 	c.TokenService = &TokenService{client: c}

--- a/buddy/target.go
+++ b/buddy/target.go
@@ -1,0 +1,55 @@
+package buddy
+
+import "net/http"
+
+// TargetService handles communication with target related methods of the Buddy API.
+type TargetService struct {
+	client *Client
+}
+
+type Target struct {
+	Url     string `json:"url"`
+	HtmlUrl string `json:"html_url"`
+	Id      int    `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+}
+
+type Targets struct {
+	Url     string    `json:"url"`
+	HtmlUrl string    `json:"html_url"`
+	Targets []*Target `json:"targets"`
+}
+
+type TargetOps struct {
+	Name *string `json:"name,omitempty"`
+	Type *string `json:"type,omitempty"`
+}
+
+func (s *TargetService) Create(workspaceDomain, projectName string, ops *TargetOps) (*Target, *http.Response, error) {
+	var t *Target
+	resp, err := s.client.Create(s.client.NewUrlPath("/workspaces/%s/projects/%s/targets", workspaceDomain, projectName), &ops, nil, &t)
+	return t, resp, err
+}
+
+func (s *TargetService) Update(workspaceDomain, projectName string, targetId int, ops *TargetOps) (*Target, *http.Response, error) {
+	var t *Target
+	resp, err := s.client.Patch(s.client.NewUrlPath("/workspaces/%s/projects/%s/targets/%d", workspaceDomain, projectName, targetId), &ops, nil, &t)
+	return t, resp, err
+}
+
+func (s *TargetService) Get(workspaceDomain, projectName string, targetId int) (*Target, *http.Response, error) {
+	var t *Target
+	resp, err := s.client.Get(s.client.NewUrlPath("/workspaces/%s/projects/%s/targets/%d", workspaceDomain, projectName, targetId), &t, nil)
+	return t, resp, err
+}
+
+func (s *TargetService) GetList(workspaceDomain, projectName string) (*Targets, *http.Response, error) {
+	var l *Targets
+	resp, err := s.client.Get(s.client.NewUrlPath("/workspaces/%s/projects/%s/targets", workspaceDomain, projectName), &l, nil)
+	return l, resp, err
+}
+
+func (s *TargetService) Delete(workspaceDomain, projectName string, targetId int) (*http.Response, error) {
+	return s.client.Delete(s.client.NewUrlPath("/workspaces/%s/projects/%s/targets/%d", workspaceDomain, projectName, targetId), nil, nil)
+}


### PR DESCRIPTION
## Summary
- support target operations via new service

## Testing
- `make lint` *(fails: no route to host)*
- `make test_dev` *(fails: connection issues)*